### PR TITLE
Fix strict errors and issues found during workshop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ before_script:
 script:
   - sh -c "if [ '$COVERALLS' = '1' ]; then phpunit --stderr --coverage-clover build/logs/clover.xml; fi"
   - sh -c "if [ '$COVERALLS' = '1' ]; then php vendor/bin/coveralls -v; fi"
-  - sh -c "if [ '$DEFAULT' = '1' ]; then phpunit --stderr; fi"
+  - sh -c "if [ '$DEFAULT' = '1' ]; then vendor/bin/phpunit --stderr; fi"
   - sh -c "if [ '$PHPCS' = '1' ]; then vendor/bin/phpcs -n -p --extensions=php --standard=vendor/cakephp/cakephp-codesniffer/CakePHP --ignore=vendor --ignore=docs --ignore=tests/bootstrap.php . ; fi"
 
 notifications:

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "league/fractal": "^0.14.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.33",
+        "phpunit/phpunit": "^6.0",
         "friendsofcake/cakephp-test-utilities": "dev-master",
         "cakephp/cakephp-codesniffer": "dev-master",
         "satooshi/php-coveralls": "dev-master"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "league/fractal": "^0.14.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0",
+        "phpunit/phpunit": "4.1.*",
         "friendsofcake/cakephp-test-utilities": "dev-master",
         "cakephp/cakephp-codesniffer": "dev-master",
         "satooshi/php-coveralls": "dev-master"

--- a/src/View/TransformerView.php
+++ b/src/View/TransformerView.php
@@ -62,7 +62,6 @@ class TransformerView extends SerializedView
         return json_encode($manager->createData($resource)->toArray());
     }
 
-
     /**
      * Retrieves a configured serializer instance. Defaults to an instance of
      * \League\Fractal\Serializer\DataArraySerializer
@@ -89,6 +88,7 @@ class TransformerView extends SerializedView
         if (!($serializer instanceof SerializerAbstract)) {
             throw new Exception(sprintf('Configured Serializer not instance of SerializerAbstract: %s', get_class($serializer)));
         }
+
         return $serializer;
     }
 
@@ -109,6 +109,7 @@ class TransformerView extends SerializedView
             if (!($transformer instanceof TransformerAbstract)) {
                 throw new Exception(sprintf('Configured Transformer not instance of TransformerAbstract: %s', get_class($transformer)));
             }
+
             return $transformer;
         }
 
@@ -136,6 +137,7 @@ class TransformerView extends SerializedView
         if (!($transformer instanceof TransformerAbstract)) {
             throw new Exception(sprintf('Transformer class not instance of TransformerAbstract: %s', $transformerClass));
         }
+
         return $transformer;
     }
 }

--- a/src/View/TransformerView.php
+++ b/src/View/TransformerView.php
@@ -59,6 +59,7 @@ class TransformerView extends SerializedView
         $serializer = $this->_serializer();
         $manager = new Manager;
         $manager->setSerializer(new $serializer());
+
         return json_encode($manager->createData($resource)->toArray());
     }
 

--- a/src/View/TransformerView.php
+++ b/src/View/TransformerView.php
@@ -3,8 +3,8 @@ namespace FractalEntities\View;
 
 use Cake\Core\Configure;
 use Cake\Datasource\EntityInterface;
+use Cake\Datasource\ResultSetInterface;
 use Cake\ORM\Query;
-use Cake\ORM\ResultSet;
 use Cake\Utility\Inflector;
 use Cake\View\SerializedView;
 use Exception;
@@ -48,7 +48,7 @@ class TransformerView extends SerializedView
 
         $transformer = $this->_transformer();
         $_serialize = $this->get(array_pop($_serialize), null);
-        if (is_array($_serialize) || $_serialize instanceof Query || $_serialize instanceof ResultSet) {
+        if (is_array($_serialize) || $_serialize instanceof Query || $_serialize instanceof ResultSetInterface) {
             $resource = new Collection($_serialize, $transformer);
         } elseif ($_serialize instanceof EntityInterface) {
             $resource = new Item($_serialize, $transformer);

--- a/src/View/TransformerView.php
+++ b/src/View/TransformerView.php
@@ -36,9 +36,10 @@ class TransformerView extends SerializedView
     /**
      * Serialize view vars.
      *
+     * @param array $serialize The data to serialize
      * @return string The serialized data
      */
-    protected function _serialize()
+    protected function _serialize($serialize)
     {
         $_serialize = (array)$this->get('_serialize', null);
         if (is_array($_serialize) && count($_serialize) > 1) {

--- a/tests/App/Transformer/TestTransformer.php
+++ b/tests/App/Transformer/TestTransformer.php
@@ -11,6 +11,7 @@ class TestTransformer extends TransformerAbstract
         if (is_object($data) && $data instanceof EntityInterface) {
             return $data->toArray();
         }
+
         return $data;
     }
 }

--- a/tests/TestCase/View/TransformerViewTest.php
+++ b/tests/TestCase/View/TransformerViewTest.php
@@ -48,7 +48,8 @@ class TransformerViewTest extends TestCase
 
     public function testSerializeRender()
     {
-        $request = $this->getMock('\Cake\Network\Request');
+        $request = $this->getMockBuilder('\Cake\Network\Request')
+            ->getMock();
         $request->expects($this->at(3))
                     ->method('param')
                     ->will($this->returnValue('Test'));
@@ -68,12 +69,13 @@ class TransformerViewTest extends TestCase
     {
         $view = new TransformerView;
         $view->set('_serialize', ['data', 'data']);
-        $this->protectedMethodCall($view, '_serialize');
+        $view->render();
     }
 
     public function testValidSerializeArray()
     {
-        $request = $this->getMock('\Cake\Network\Request');
+        $request = $this->getMockBuilder('\Cake\Network\Request')
+            ->getMock();
         $request->expects($this->at(3))
                     ->method('param')
                     ->will($this->returnValue('Test'));
@@ -81,18 +83,20 @@ class TransformerViewTest extends TestCase
         $view = new TransformerView($request);
         $view->set('data', [['key' => 'value']]);
         $view->set('_serialize', 'data');
-        $result = $this->protectedMethodCall($view, '_serialize');
+        $result = $view->render();
         $this->assertEquals(json_encode(['data' => [['key' => 'value']]]), $result);
     }
 
     public function testValidSerializeEntity()
     {
-        $request = $this->getMock('\Cake\Network\Request');
+        $request = $this->getMockBuilder('\Cake\Network\Request')
+            ->getMock();
         $request->expects($this->at(3))
                     ->method('param')
                     ->will($this->returnValue('Test'));
 
-        $entity = $this->getMock('\Cake\Datasource\EntityInterface');
+        $entity = $this->getMockBuilder('\Cake\Datasource\EntityInterface')
+            ->getMock();
         $entity->expects($this->once())
                     ->method('toArray')
                     ->will($this->returnValue(['key' => 'value']));
@@ -100,7 +104,7 @@ class TransformerViewTest extends TestCase
         $view = new TransformerView($request);
         $view->set('data', $entity);
         $view->set('_serialize', 'data');
-        $result = $this->protectedMethodCall($view, '_serialize');
+        $result = $view->render();
         $this->assertEquals(json_encode(['data' => ['key' => 'value']]), $result);
     }
 
@@ -110,7 +114,8 @@ class TransformerViewTest extends TestCase
      */
     public function testInvalidValidSerialize()
     {
-        $request = $this->getMock('\Cake\Network\Request');
+        $request = $this->getMockBuilder('\Cake\Network\Request')
+            ->getMock();
         $request->expects($this->at(3))
                     ->method('param')
                     ->will($this->returnValue('Test'));
@@ -118,12 +123,14 @@ class TransformerViewTest extends TestCase
         $view = new TransformerView($request);
         $view->set('data', new stdClass);
         $view->set('_serialize', 'data');
-        $this->protectedMethodCall($view, '_serialize');
+        $view->render();
     }
+
     public function testValidSerializer()
     {
         $view = new TransformerView;
-        $view->set('_serializer', $this->getMock('\League\Fractal\Serializer\SerializerAbstract'));
+        $mock = $this->getMockBuilder('\League\Fractal\Serializer\SerializerAbstract')->getMock();
+        $view->set('_serializer', $mock);
         $result = $this->protectedMethodCall($view, '_serializer');
         $this->assertInstanceOf('\League\Fractal\Serializer\SerializerAbstract', $result);
     }
@@ -172,7 +179,8 @@ class TransformerViewTest extends TestCase
     public function testValidTransformer()
     {
         $view = new TransformerView;
-        $view->set('_transformer', $this->getMock('\League\Fractal\TransformerAbstract'));
+        $mock = $this->getMockBuilder('\League\Fractal\TransformerAbstract')->getMock();
+        $view->set('_transformer', $mock);
         $result = $this->protectedMethodCall($view, '_transformer');
         $this->assertInstanceOf('\League\Fractal\TransformerAbstract', $result);
     }
@@ -190,7 +198,7 @@ class TransformerViewTest extends TestCase
 
     public function testValidAutomaticTransformerClass()
     {
-        $request = $this->getMock('\Cake\Network\Request');
+        $request = $this->getMockBuilder('\Cake\Network\Request')->getMock();
         $request->expects($this->at(3))
                     ->method('param')
                     ->will($this->returnValue('Test'));
@@ -217,7 +225,8 @@ class TransformerViewTest extends TestCase
      */
     public function testInvalidAutomaticTransformerClass()
     {
-        $request = $this->getMock('\Cake\Network\Request');
+        $request = $this->getMockBuilder('\Cake\Network\Request')
+            ->getMock();
         $request->expects($this->at(3))
                     ->method('param')
                     ->will($this->returnValue('Invalid'));

--- a/tests/TestCase/View/TransformerViewTest.php
+++ b/tests/TestCase/View/TransformerViewTest.php
@@ -247,6 +247,7 @@ class TransformerViewTest extends TestCase
         $class = new \ReflectionClass($obj);
         $method = $class->getMethod($name);
         $method->setAccessible(true);
+
         return $method->invokeArgs($obj, $args);
     }
 }

--- a/tests/TestCase/View/TransformerViewTest.php
+++ b/tests/TestCase/View/TransformerViewTest.php
@@ -51,8 +51,8 @@ class TransformerViewTest extends TestCase
         $request = $this->getMockBuilder('\Cake\Network\Request')
             ->getMock();
         $request->expects($this->at(3))
-                    ->method('param')
-                    ->will($this->returnValue('Test'));
+            ->method('param')
+            ->will($this->returnValue('Test'));
 
         $view = new TransformerView($request);
         $view->set('data', [['key' => 'value']]);
@@ -77,8 +77,8 @@ class TransformerViewTest extends TestCase
         $request = $this->getMockBuilder('\Cake\Network\Request')
             ->getMock();
         $request->expects($this->at(3))
-                    ->method('param')
-                    ->will($this->returnValue('Test'));
+            ->method('param')
+            ->will($this->returnValue('Test'));
 
         $view = new TransformerView($request);
         $view->set('data', [['key' => 'value']]);
@@ -92,14 +92,14 @@ class TransformerViewTest extends TestCase
         $request = $this->getMockBuilder('\Cake\Network\Request')
             ->getMock();
         $request->expects($this->at(3))
-                    ->method('param')
-                    ->will($this->returnValue('Test'));
+            ->method('param')
+            ->will($this->returnValue('Test'));
 
         $entity = $this->getMockBuilder('\Cake\Datasource\EntityInterface')
             ->getMock();
         $entity->expects($this->once())
-                    ->method('toArray')
-                    ->will($this->returnValue(['key' => 'value']));
+            ->method('toArray')
+            ->will($this->returnValue(['key' => 'value']));
 
         $view = new TransformerView($request);
         $view->set('data', $entity);
@@ -117,8 +117,8 @@ class TransformerViewTest extends TestCase
         $request = $this->getMockBuilder('\Cake\Network\Request')
             ->getMock();
         $request->expects($this->at(3))
-                    ->method('param')
-                    ->will($this->returnValue('Test'));
+            ->method('param')
+            ->will($this->returnValue('Test'));
 
         $view = new TransformerView($request);
         $view->set('data', new stdClass);
@@ -200,8 +200,8 @@ class TransformerViewTest extends TestCase
     {
         $request = $this->getMockBuilder('\Cake\Network\Request')->getMock();
         $request->expects($this->at(3))
-                    ->method('param')
-                    ->will($this->returnValue('Test'));
+            ->method('param')
+            ->will($this->returnValue('Test'));
 
         $view = new TransformerView($request);
         $result = $this->protectedMethodCall($view, '_transformer');
@@ -218,7 +218,6 @@ class TransformerViewTest extends TestCase
         $this->protectedMethodCall($view, '_transformer');
     }
 
-
     /**
      * @expectedException Exception
      * @expectedExceptionMessage Transformer class not instance of TransformerAbstract: \FractalEntities\Test\App\Transformer\InvalidTransformer
@@ -228,8 +227,8 @@ class TransformerViewTest extends TestCase
         $request = $this->getMockBuilder('\Cake\Network\Request')
             ->getMock();
         $request->expects($this->at(3))
-                    ->method('param')
-                    ->will($this->returnValue('Invalid'));
+            ->method('param')
+            ->will($this->returnValue('Invalid'));
 
         $view = new TransformerView($request);
         $this->protectedMethodCall($view, '_transformer');


### PR DESCRIPTION
* Fix strict errors that are emitted on 3.2+
* Upgrade PHPUnit and fix deprecation warnings.
* Fix incompatibility with decorated results.